### PR TITLE
Tests Added

### DIFF
--- a/agent/acs/client/acs_client_test.go
+++ b/agent/acs/client/acs_client_test.go
@@ -135,7 +135,6 @@ func TestWriteAckRequest(t *testing.T) {
 	assert.Equal(t, "AckRequest", msg.Type)
 }
 
-// Sample
 func TestPayloadHandlerCalled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/acs/client/acs_client_test.go
+++ b/agent/acs/client/acs_client_test.go
@@ -135,6 +135,7 @@ func TestWriteAckRequest(t *testing.T) {
 	assert.Equal(t, "AckRequest", msg.Type)
 }
 
+// Sample
 func TestPayloadHandlerCalled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -31,8 +31,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-const currentCNISpec = "0.3.1"
-
+const (
+	currentCNISpec = "0.3.1"
+	currentCNIVersion = "2018.08.0"
+	CNIVersionFilePath = "../../amazon-ecs-cni-plugins/VERSION"
+	CNIGitHash = "a134a973585b560439ed25ec3857e4789bfeb89f"
+)
 // CNIClient defines the method of setting/cleaning up container namespace
 type CNIClient interface {
 	// Version returns the version of the plugin

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -263,22 +263,25 @@ func TestCNIPluginVersion(t *testing.T) {
 	}
 }
 
+// Returns the version in CNI plugin VERSION file as a string
 func getCNIVersionString(t *testing.T) string {
 	versionStr, err := ioutil.ReadFile(CNIVersionFilePath)
 	assert.NoError(t, err, "Error reading the CNI plugin version file")
 	return strings.TrimSpace(string(versionStr))
 }
 
+// Asserts that CNI plugin version matches the expected version
 func TestCNIPluginVersionNumber(t *testing.T) {
 	var versionStr = getCNIVersionString(t)
 	assert.Equal(t, currentCNIVersion, versionStr)
 }
 
+// Asserts that CNI plugin version is upgraded when new commits are made to CNI plugin submodule
 func TestCNIPluginVersionUpgrade(t *testing.T) {
 	var versionStr = getCNIVersionString(t)
 	cmd := exec.Command("git", "submodule")
 	versionInfo, err := cmd.Output()
-	versionInfoStr := string((versionInfo))
+	versionInfoStr := string(versionInfo)
 	assert.NoError(t, err, "Error running the command: git submodule")
 	// If a new commit is added, version should be upgraded
 	if (string(CNIGitHash) != strings.Split(versionInfoStr, " ")[1]) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
